### PR TITLE
Better git

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -1,7 +1,7 @@
 export { GHActServer } from "./src/GHActServer.ts";
 export { GHActWorker } from "./src/GHActWorker.ts";
 export { GitRepository } from "./src/GitRepository.ts";
-export { combineCommandOutputs } from "./src/log.ts";
+export { combineCommandOutputs, LogFn } from "./src/log.ts";
 
 /**
  * Options for configuring GHAct
@@ -117,23 +117,9 @@ export interface FullUpdateJob extends BasicJob {
  * Represents the task of gathering files for full_update
  */
 export interface FullUpdateGatherJob extends BasicJob {
+  /** Type of the Job */
   type: "full_update_gather";
 }
 
 /** Describes a Job */
 export type Job = WebhookJob | FullUpdateJob | BasicJob;
-
-/**
- * This function is passed to the jobHandler and is used to log messages to the
- * respective logfiles. It will also log the messages to the console.
- *
- * If a string is passed, the promise is resolved instantly, and it may be
- * treated as a sync function returning void.
- *
- * If a ReadableStream is passed (e.g. output from an external command) then the
- * promise only resolves after the write has finished. In this case you must
- * await the promise.
- */
-export type LogFn = (
-  message: string | ReadableStream<Uint8Array>,
-) => Promise<void>;

--- a/mod.ts
+++ b/mod.ts
@@ -1,6 +1,7 @@
 export { GHActServer } from "./src/GHActServer.ts";
 export { GHActWorker } from "./src/GHActWorker.ts";
 export { type ChangeSummary, GitRepository } from "./src/GitRepository.ts";
+export { combineCommandOutputs } from "./src/log.ts";
 
 /**
  * Options for configuring GHAct

--- a/mod.ts
+++ b/mod.ts
@@ -78,3 +78,18 @@ export interface Job {
     removed?: string[];
   };
 }
+
+/**
+ * This function is passed to the jobHandler and is used to log messages to the
+ * respective logfiles. It will also log the messages to the console.
+ *
+ * If a string is passed, the promise is resolved instantly, and it may be
+ * treated as a sync function returning void.
+ *
+ * If a ReadableStream is passed (e.g. output from an external command) then the
+ * promise only resolves after the write has finished. In this case you must
+ * await the promise.
+ */
+export type LogFn = (
+  message: string | ReadableStream<Uint8Array>,
+) => Promise<void>;

--- a/src/GHActServer.ts
+++ b/src/GHActServer.ts
@@ -61,9 +61,11 @@ export class GHActServer {
         j.status === "completed" || j.status === "failed"
       )
         ?.status || "Unknown";
-    if (latest === "failed") createBadge("Failed", this.config.workDir, this.config.title);
-    else if (latest === "completed") createBadge("OK", this.config.workDir, this.config.title);
-    else createBadge("Unknown", this.config.workDir, this.config.title);
+    if (latest === "failed") {
+      createBadge("Failed", this.config.workDir, this.config.title);
+    } else if (latest === "completed") {
+      createBadge("OK", this.config.workDir, this.config.title);
+    } else createBadge("Unknown", this.config.workDir, this.config.title);
 
     if (
       !this.config.sourceRepositoryUri.includes(this.config.sourceRepository)

--- a/src/GHActServer.ts
+++ b/src/GHActServer.ts
@@ -5,7 +5,12 @@ import {
   STATUS_CODE,
   STATUS_TEXT,
 } from "./deps.ts";
-import { type Config, type Job } from "../mod.ts";
+import {
+  type BasicJob,
+  type Config,
+  type FullUpdateGatherJob,
+  type WebhookJob,
+} from "../mod.ts";
 import { createBadge } from "./log.ts";
 import { JobsDataBase } from "./JobsDataBase.ts";
 import { indexPage } from "./indexPage.ts";
@@ -22,6 +27,11 @@ type webhookPayload = {
     name: string;
     email: string;
   };
+  commits: {
+    added: string[];
+    removed: string[];
+    modified: string[];
+  }[];
 };
 
 const WEBHOOK_SECRET: string | undefined = Deno.env.get("WEBHOOK_SECRET");
@@ -111,7 +121,7 @@ export class GHActServer {
         }
         const till = requestUrl.searchParams.get("till") || "HEAD";
         // console.log(await getModifiedAfter(from));
-        const job: Job = {
+        const job: BasicJob = {
           id: (new Date()).toISOString(),
           from,
           till,
@@ -132,7 +142,19 @@ export class GHActServer {
       }
       if (pathname === "/full_update") {
         console.log("· got full_update request");
-        this.worker.postMessage("FULLUPDATE");
+        const job: FullUpdateGatherJob = {
+          type: "full_update_gather",
+          id: (new Date()).toISOString() + " full update gathering",
+          author: {
+            name: this.config.title,
+            email: this.config.email,
+          },
+        };
+        this.db.addJob(job);
+        this.worker.postMessage(job);
+        console.log(
+          `Job submitted: ${JSON.stringify(job, undefined, 2)}`,
+        );
         return new Response(undefined, {
           status: STATUS_CODE.Accepted,
           statusText: STATUS_TEXT[STATUS_CODE.Accepted],
@@ -165,11 +187,18 @@ export class GHActServer {
               statusText: STATUS_TEXT[STATUS_CODE.BadRequest],
             });
           }
-          const job: Job = {
+          const job: WebhookJob = {
             id: (new Date()).toISOString(),
             from: json.before,
             till: json.after,
             author: json.pusher,
+            files: {
+              from: json.before,
+              till: json.after,
+              added: json.commits.flatMap((c) => c.added),
+              removed: json.commits.flatMap((c) => c.removed),
+              modified: json.commits.flatMap((c) => c.modified),
+            },
           };
           this.db.addJob(job);
           this.worker.postMessage(job);

--- a/src/GHActWorker.ts
+++ b/src/GHActWorker.ts
@@ -99,7 +99,7 @@ export class GHActWorker {
           },
         );
       };
-      this.gitRepository.updateLocalData();
+      this.gitRepository.updateLocalData(log);
       try {
         this.queue.setStatus(job, "pending");
         await this.jobHandler(job, log);

--- a/src/GHActWorker.ts
+++ b/src/GHActWorker.ts
@@ -91,17 +91,7 @@ export class GHActWorker {
       const job = jobStatus.job;
 
       const log: LogFn = (msg) => {
-        if (typeof msg === "string") {
-          Deno.writeTextFileSync(
-            path.join(jobStatus.dir, "log.txt"),
-            msg + "\n",
-            {
-              append: true,
-            },
-          );
-          console.log(msg);
-          return Promise.resolve();
-        } else {
+        if (msg instanceof ReadableStream) {
           const [toConsole, toFile] = msg.tee();
           return Promise.allSettled([
             toConsole.pipeTo(Deno.stdout.writable, {
@@ -115,6 +105,16 @@ export class GHActWorker {
               }).writable,
             ),
           ]).then(() => {});
+        } else {
+          Deno.writeTextFileSync(
+            path.join(jobStatus.dir, "log.txt"),
+            msg + "\n",
+            {
+              append: true,
+            },
+          );
+          console.log(msg);
+          return Promise.resolve();
         }
       };
 

--- a/src/GHActWorker.ts
+++ b/src/GHActWorker.ts
@@ -94,7 +94,7 @@ export class GHActWorker {
 
       try {
         this.queue.setStatus(job, "pending");
-        await log(`=== Starting job ${job.id} ===`);
+        log(`=== Starting job ${job.id} ===`);
         if ("type" in job && job.type === "full_update_gather") {
           await this.gatherJobsForFullUpdate(job, log);
           // gatherJobsForFullUpdate handles setting job status itself
@@ -102,14 +102,14 @@ export class GHActWorker {
           await this.gitRepository.updateLocalData(log);
           await this.jobHandler(job, log);
           this.queue.setStatus(job, "completed");
-          await log(`=== Sucessfully completed job ${job.id} ===`);
+          log(`=== Sucessfully completed job ${job.id} ===`);
           createBadge("OK", this.config.workDir, this.config.title);
         }
       } catch (error) {
         this.queue.setStatus(job, "failed");
-        await log(`=== Failed job ${job.id} ===\n=== Error: ===`);
-        await log(error);
-        if (error.stack) await log(error.stack);
+        log(`=== Failed job ${job.id} ===\n=== Error: ===`);
+        log(error);
+        if (error.stack) log(error.stack);
         createBadge("Failed", this.config.workDir, this.config.title);
       }
     }
@@ -149,7 +149,7 @@ export class GHActWorker {
             files = [];
           }
         } else {
-          await log(`skipped ${walkEntry.path}`);
+          log(`skipped ${walkEntry.path}`);
         }
       }
       if (files.length > 0) {
@@ -166,14 +166,14 @@ export class GHActWorker {
         j.id += ` of ${block.toString(10).padStart(3, "0")}`;
         this.queue.addJob(j);
       });
-      await log(`Created ${block} jobs for full update`);
-      await log(`=== Sucessfully completed job ${job.id} ===`);
+      log(`Created ${block} jobs for full update`);
+      log(`=== Sucessfully completed job ${job.id} ===`);
       this.queue.setStatus(job, "completed");
     } catch (error) {
       this.queue.setStatus(job, "failed");
-      await log(`=== Failed job ${job.id} ===\n=== Error: ===`);
-      await log(error);
-      if (error.stack) await log(error.stack);
+      log(`=== Failed job ${job.id} ===\n=== Error: ===`);
+      log(error);
+      if (error.stack) log(error.stack);
     } finally {
       this.isRunning = false;
       await this.startTask();

--- a/src/GitRepository.ts
+++ b/src/GitRepository.ts
@@ -79,10 +79,15 @@ export class GitRepository {
   /**
    * Clones the repo into the directory (git clone).
    *
-   * Please ensure that the directory is empty beforehand
-   * or use `.updateLocalData()` if the repository may already be cloned, `.updateLocalData()` will only clone if neccesary.
+   * Please ensure that the directory is empty beforehand or use
+   * `.updateLocalData()` if the repository may already be cloned,
+   * `.updateLocalData()` will only clone if neccesary.
+   *
+   * @param {boolean} [blobless=true] Whether to use --filter=blob:none to
+   * exclude previous verisions of files. May or may not speed up the clone;
+   * will reduce the amount of storage occupied by the repository.
    */
-  cloneRepo(log: (msg: string) => void = console.log) {
+  cloneRepo(log: (msg: string) => void = console.log, blobless = true) {
     log(`Cloning ${this.uri}. This will take some time.`);
     if (existsSync(this.directory)) {
       Deno.mkdirSync(this.directory, { recursive: true });
@@ -93,9 +98,9 @@ export class GitRepository {
         "--single-branch",
         "--quiet",
         // this will make it download only blobs(=files) as present in the
-        // latest commit. History and histroical trees are still cloned, but old
+        // latest commit. History and historical trees are still cloned, but old
         // verions of files are only downloaded if needed (e.g. by git diff)
-        "--filter=blob:none",
+        blobless ? "--filter=blob:none" : "",
         `--branch=${this.branch}`,
         this.authUri,
         `.`,

--- a/src/GitRepository.ts
+++ b/src/GitRepository.ts
@@ -92,8 +92,11 @@ export class GitRepository {
         "clone",
         "--single-branch",
         "--quiet",
-        `--branch`,
-        `${this.branch}`,
+        // this will make it download only blobs(=files) as present in the
+        // latest commit. History and histroical trees are still cloned, but old
+        // verions of files are only downloaded if needed (e.g. by git diff)
+        "--filter=blob:none",
+        `--branch=${this.branch}`,
         this.authUri,
         `.`,
       ],

--- a/src/GitRepository.ts
+++ b/src/GitRepository.ts
@@ -1,18 +1,8 @@
-import { type ChangeSummary, type Job, type LogFn } from "../mod.ts";
+import { type ChangeSummary, type Job } from "../mod.ts";
 import { existsSync } from "./deps.ts";
-import { combineCommandOutputs, commandOutputToLines } from "./log.ts";
+import { combineCommandOutputs, commandOutputToLines, LogFn } from "./log.ts";
 
-const consoleLog: LogFn = (msg) => {
-  if (msg instanceof ReadableStream) {
-    return msg.pipeTo(Deno.stdout.writable, {
-      preventCancel: true,
-      preventClose: true,
-    });
-  } else {
-    console.log(msg);
-    return Promise.resolve();
-  }
-};
+const consoleLog = new LogFn(false, true);
 
 /**
  * Represents a git repository on disk, with convenience functions to manage it.

--- a/src/GitRepository.ts
+++ b/src/GitRepository.ts
@@ -1,4 +1,5 @@
 import { type Job } from "../mod.ts";
+import { existsSync } from "./deps.ts";
 
 /**
  * added, removed and modified contiain the respective changed files as a list of paths (strings)
@@ -83,6 +84,9 @@ export class GitRepository {
    */
   cloneRepo(log: (msg: string) => void = console.log) {
     log(`Cloning ${this.uri}. This will take some time.`);
+    if (existsSync(this.directory)) {
+      Deno.mkdirSync(this.directory, { recursive: true });
+    }
     const p = new Deno.Command("/usr/bin/git", {
       args: [
         "clone",
@@ -122,7 +126,7 @@ export class GitRepository {
   ) {
     log("starting git pull...");
 
-    if (Deno.statSync(`${this.directory}/.git`).isDirectory) {
+    if (existsSync(this.directory) && existsSync(`${this.directory}/.git`)) {
       const p = new Deno.Command("/usr/bin/git", {
         args: ["pull"],
         env: {

--- a/src/GitRepository.ts
+++ b/src/GitRepository.ts
@@ -96,11 +96,11 @@ export class GitRepository {
    * `.updateLocalData()` if the repository may already be cloned,
    * `.updateLocalData()` will only clone if neccesary.
    *
-   * @param {boolean} [blobless=true] Whether to use --filter=blob:none to
+   * @param {boolean} [blobless=false] Whether to use --filter=blob:none to
    * exclude previous verisions of files. May or may not speed up the clone;
    * will reduce the amount of storage occupied by the repository.
    */
-  async cloneRepo(log: LogFn = consoleLog, blobless = true) {
+  async cloneRepo(log: LogFn = consoleLog, blobless = false) {
     await log(`Cloning ${this.uri}. This will take some time.`);
     if (existsSync(this.directory)) {
       Deno.mkdirSync(this.directory, { recursive: true });

--- a/src/GitRepository.ts
+++ b/src/GitRepository.ts
@@ -17,14 +17,14 @@ export interface ChangeSummary {
 }
 
 const consoleLog: LogFn = (msg) => {
-  if (typeof msg === "string") {
-    console.log(msg);
-    return Promise.resolve();
-  } else {
+  if (msg instanceof ReadableStream) {
     return msg.pipeTo(Deno.stdout.writable, {
       preventCancel: true,
       preventClose: true,
     });
+  } else {
+    console.log(msg);
+    return Promise.resolve();
   }
 };
 

--- a/src/GitRepository.ts
+++ b/src/GitRepository.ts
@@ -122,27 +122,29 @@ export class GitRepository {
   ) {
     log("starting git pull...");
 
-    const p = new Deno.Command("/usr/bin/git", {
-      args: ["pull"],
-      env: {
-        GIT_CEILING_DIRECTORIES: this.directory,
-      },
-      cwd: this.directory,
-    });
-    const { success, stdout, stderr } = p.outputSync();
-    if (!success) {
-      log("git pull failed:");
-    } else {
-      log("git pull successful:");
+    if (Deno.statSync(`${this.directory}/.git`).isDirectory) {
+      const p = new Deno.Command("/usr/bin/git", {
+        args: ["pull"],
+        env: {
+          GIT_CEILING_DIRECTORIES: this.directory,
+        },
+        cwd: this.directory,
+      });
+      const { success, stdout, stderr } = p.outputSync();
+      if (!success) {
+        log("git pull failed:");
+      } else {
+        log("git pull successful:");
+      }
+      log(new TextDecoder().decode(stdout));
+      log("STDERR:");
+      log(new TextDecoder().decode(stderr));
+      log("STDOUT:");
+      if (success) return;
     }
-    log(new TextDecoder().decode(stdout));
-    log("STDERR:");
-    log(new TextDecoder().decode(stderr));
-    log("STDOUT:");
-    if (!success) {
-      this.emptyDataDir();
-      this.cloneRepo(log);
-    }
+
+    this.emptyDataDir();
+    this.cloneRepo(log);
   }
 
   /**

--- a/src/GitRepository.ts
+++ b/src/GitRepository.ts
@@ -77,7 +77,7 @@ export class GitRepository {
    * will reduce the amount of storage occupied by the repository.
    */
   async cloneRepo(log: LogFn = consoleLog, blobless = false) {
-    await log(
+    log(
       `== starting git clone for ${this.uri} ==\n== this may take some time ==`,
     );
     if (existsSync(this.directory)) {
@@ -106,9 +106,9 @@ export class GitRepository {
     const { success } = await child.status;
 
     if (success) {
-      await log("== git clone successful ==");
+      log("== git clone successful ==");
     } else {
-      await log("== git clone failed ==");
+      log("== git clone failed ==");
       throw new Error(
         `Cloning of ${this.uri} into ${this.directory} failed, see logs.`,
       );
@@ -121,7 +121,7 @@ export class GitRepository {
    * if it fails, it automatically calls `this.emptyDataDir()` and `this.cloneRepo(log)`.
    */
   async updateLocalData(log: LogFn = consoleLog) {
-    await log("== starting git pull ==");
+    log("== starting git pull ==");
 
     if (existsSync(this.directory) && existsSync(`${this.directory}/.git`)) {
       const command = new Deno.Command("/usr/bin/git", {
@@ -139,9 +139,9 @@ export class GitRepository {
       const { success } = await child.status;
 
       if (!success) {
-        await log("== git pull failed, will attempt to clone instead ==");
+        log("== git pull failed, will attempt to clone instead ==");
       } else {
-        await log("== git pull successful ==");
+        log("== git pull successful ==");
       }
       if (success) return;
     }
@@ -165,7 +165,7 @@ export class GitRepository {
     log: LogFn = consoleLog,
   ): Promise<ChangeSummary> {
     await this.updateLocalData(log);
-    await log("== git diff ==");
+    log("== git diff ==");
     const command = new Deno.Command("/usr/bin/git", {
       args: [
         "diff",
@@ -231,7 +231,7 @@ export class GitRepository {
    * Wrapper for `git push`
    */
   async push(log: LogFn = consoleLog) {
-    await log("== git push ==");
+    log("== git push ==");
     const command = new Deno.Command("/usr/bin/git", {
       args: [
         "push",
@@ -262,7 +262,7 @@ export class GitRepository {
    * ```
    */
   async commit(job: Job, message: string, log: LogFn = consoleLog) {
-    await log("== git commit ==");
+    log("== git commit ==");
     const commands = `git config --replace-all user.name ${job.author.name}
                       git config --replace-all user.email ${job.author.email}
                       git add -A

--- a/src/JobsDataBase.ts
+++ b/src/JobsDataBase.ts
@@ -3,10 +3,10 @@ import { path } from "./deps.ts";
 
 //const jobsDir = `${config.workDir}/log`;
 
-import { type Job } from "../mod.ts";
+import { type FullUpdateGatherJob, type Job } from "../mod.ts";
 
 export type JobStatus = {
-  job: Job;
+  job: Job | FullUpdateGatherJob;
   status: "pending" | "failed" | "completed";
   dir: string;
 };
@@ -22,7 +22,7 @@ export class JobsDataBase {
     Deno.mkdirSync(jobsDir, { recursive: true });
   }
 
-  addJob(job: Job) {
+  addJob(job: Job | FullUpdateGatherJob) {
     const status: JobStatus = {
       job,
       status: "pending",
@@ -35,7 +35,10 @@ export class JobsDataBase {
     );
   }
 
-  setStatus(job: Job, status: "failed" | "completed" | "pending") {
+  setStatus(
+    job: Job | FullUpdateGatherJob,
+    status: "failed" | "completed" | "pending",
+  ) {
     const jobStatus: JobStatus = {
       job,
       status,

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -8,6 +8,5 @@ export {
   serveDir,
   serveFile,
 } from "https://deno.land/std@0.224.0/http/file_server.ts";
-
-export { walk } from "https://deno.land/std@0.224.0/fs/mod.ts";
+export { existsSync, walk } from "https://deno.land/std@0.224.0/fs/mod.ts";
 export * as path from "https://deno.land/std@0.224.0/path/mod.ts";

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -3,10 +3,16 @@ export {
   STATUS_CODE,
   STATUS_TEXT,
 } from "https://deno.land/std@0.224.0/http/mod.ts";
-
 export {
   serveDir,
   serveFile,
 } from "https://deno.land/std@0.224.0/http/file_server.ts";
+
 export { existsSync, walk } from "https://deno.land/std@0.224.0/fs/mod.ts";
 export * as path from "https://deno.land/std@0.224.0/path/mod.ts";
+
+export {
+  mergeReadableStreams,
+  TextLineStream,
+  toTransformStream,
+} from "https://deno.land/std@0.224.0/streams/mod.ts";

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,3 +1,9 @@
+import {
+  mergeReadableStreams,
+  TextLineStream,
+  toTransformStream,
+} from "./deps.ts";
+
 const colors = {
   OK: "#26a269",
   Failed: "#c01c28",
@@ -12,9 +18,36 @@ export const createBadge = (
   const svg = `<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg width="280" height="36" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
   <path style="fill:#5e5c64" d="M 137.99998,36 H 7.999996 C 3.568002,36 0,32.431994 0,28 V 8 C 0,3.568002 3.568002,0 7.999996,0 V 0 H 137.99998" />
-  <path style="fill:${colors[status]}" d="m 137.99998,0 h 133.99998 c 4.43199,0 7.99997,3.568002 7.99997,8 v 20 c 0,4.431994 -3.56798,8 -7.99997,8 H 137.99998" />
+  <path style="fill:${
+    colors[status]
+  }" d="m 137.99998,0 h 133.99998 c 4.43199,0 7.99997,3.568002 7.99997,8 v 20 c 0,4.431994 -3.56798,8 -7.99997,8 H 137.99998" />
   <text style="font-size:28px;font-family:sans-serif;fill:#ffffff;stroke-width:8" x="8" y="28">${name}</text>
   <text style="font-size:28px;font-family:sans-serif;fill:#ffffff;stroke-width:8" x="146" y="28">${status}</text>
 </svg>`;
   return Deno.writeTextFileSync(`${workDir}/status.svg`, svg);
+};
+
+export const combineCommandOutputs = (
+  stdout: ReadableStream<Uint8Array>,
+  stderr: ReadableStream<Uint8Array>,
+): ReadableStream<Uint8Array> => {
+  return mergeReadableStreams(
+    markCommandOutput(stdout, "OUT>"),
+    markCommandOutput(stderr, "ERR>"),
+  ).pipeThrough(new TextEncoderStream());
+};
+
+const markCommandOutput = (
+  stream: ReadableStream<Uint8Array>,
+  marker: string,
+): ReadableStream<string> => {
+  return stream
+    .pipeThrough(new TextDecoderStream())
+    .pipeThrough(new TextLineStream())
+    .pipeThrough(toTransformStream(async function* (src) {
+      for await (const chunk of src) {
+        yield `${marker} ${chunk}`;
+      }
+      yield "\n";
+    }));
 };

--- a/src/log.ts
+++ b/src/log.ts
@@ -61,7 +61,12 @@ export const commandOutputToLines = (
 ): ReadableStream<string> => {
   return stream
     .pipeThrough(new TextDecoderStream())
-    .pipeThrough(new TextLineStream());
+    .pipeThrough(new TextLineStream())
+    .pipeThrough(toTransformStream(async function* (src) {
+      for await (const chunk of src) {
+        yield chunk + "\n";
+      }
+    }));
 };
 
 const markCommandOutput = (
@@ -73,6 +78,5 @@ const markCommandOutput = (
       for await (const chunk of src) {
         yield `${marker} ${chunk}`;
       }
-      yield "\n";
     }));
 };

--- a/src/log.ts
+++ b/src/log.ts
@@ -80,3 +80,63 @@ const markCommandOutput = (
       }
     }));
 };
+
+/**
+ * A function of this type is passed to the jobHandler and is used to log messages to the
+ * respective logfiles. It will also log the messages to the console.
+ *
+ * If a string is passed, the promise is resolved instantly, and it may be
+ * treated as a sync function returning void.
+ *
+ * If a ReadableStream is passed (e.g. output from an external command) then the
+ * promise only resolves after the write has finished. In this case you must
+ * await the promise.
+ */
+export interface LogFn {
+  (message: string | ReadableStream<Uint8Array>): Promise<void>;
+}
+
+/**
+ * It is reccommended to only `import { type LogFn } from "."` as constructing
+ * new `LogFn`s should not be neccesary as a consumer of GHAct.
+ *
+ * @example
+ * ```ts
+ * const log_to_file_and_console = new LogFn("path-to-logfile.txt", true);
+ * const log_to_file_only = new LogFn("path-to-logfile.txt", false);
+ * const log_to_console_only = new LogFn(false, true);
+ * ```
+ */
+export class LogFn implements LogFn {
+  /**
+   * Creates a LogFn
+   *
+   * @param file path of log-file where messages shuld be appended or false to disable logging to disk
+   * @param stdout whether to (simultaneously) log messages to the console/stdout
+   */
+  constructor(file: string | false, stdout: boolean) {
+    return (message: string | ReadableStream<Uint8Array>): Promise<void> => {
+      if (message instanceof ReadableStream) {
+        const [forFile, forConsole] = message.tee();
+        const toFile = file
+          ? forFile.pipeTo(
+            Deno.openSync(file, { create: true, append: true }).writable,
+          )
+          : Promise.resolve();
+        const toConsole = stdout
+          ? forConsole.pipeTo(Deno.stdout.writable, {
+            preventCancel: true,
+            preventClose: true,
+          })
+          : Promise.resolve();
+        return Promise.allSettled([toFile, toConsole]).then(() => {});
+      } else {
+        if (file) {
+          Deno.writeTextFileSync(file, message + "\n", { append: true });
+        }
+        if (stdout) console.log(message);
+        return Promise.resolve();
+      }
+    };
+  }
+}

--- a/src/log.ts
+++ b/src/log.ts
@@ -37,13 +37,19 @@ export const combineCommandOutputs = (
   ).pipeThrough(new TextEncoderStream());
 };
 
+export const commandOutputToLines = (
+  stream: ReadableStream<Uint8Array>,
+): ReadableStream<string> => {
+  return stream
+    .pipeThrough(new TextDecoderStream())
+    .pipeThrough(new TextLineStream());
+};
+
 const markCommandOutput = (
   stream: ReadableStream<Uint8Array>,
   marker: string,
 ): ReadableStream<string> => {
-  return stream
-    .pipeThrough(new TextDecoderStream())
-    .pipeThrough(new TextLineStream())
+  return commandOutputToLines(stream)
     .pipeThrough(toTransformStream(async function* (src) {
       for await (const chunk of src) {
         yield `${marker} ${chunk}`;


### PR DESCRIPTION
- pipe output of git commands to log instead of waiting for the  command to finish
- side-effect: restructuring of LogFn
- optionally clone blobless, reduces size-on-disk and should in theory also speed up clones, I am unsure if that is the case tho

API changes:
- **All `GitRepository` methods are now async and must be `await`ed.**
- `log` as passed to the jobHandler now accepts either a `string` or a `ReadableStream<UInt8Array>`.
- `log` now also logs all messages to the console.
- `LogFn` is now a class, altough library-users should rarely require to make new instances.
- `GitRepostory.__prototype__.cloneRepo` now accepts a second argument `blobless` to enable/disable blobless clones (disabled by default)
- new export: helper function `combineCommandOutputs` to make piping stdout and stderr of child processes to `log` easier.